### PR TITLE
Check contract balance of outputToken on bake

### DIFF
--- a/src/Stove.sol
+++ b/src/Stove.sol
@@ -186,12 +186,22 @@ contract Stove is Ownable {
         uint256 _epoch = epoch;
         uint256 _amountInput = totalDeposits[_epoch];
 
-        (uint256 _usedInput, uint256 _bakedOutput) = IRecipe(recipe).bake(
+        uint256 _contractBalancePreBake = IERC20(tokenOutput).balanceOf(
+            address(this)
+        );
+
+        (uint256 _usedInput, ) = IRecipe(recipe).bake(
             tokenInput,
             tokenOutput,
             _amountInput,
             _data
         );
+
+        uint256 _contractBalanceAfterBake = IERC20(tokenOutput).balanceOf(
+            address(this)
+        );
+
+        uint256 _bakedOutput = _contractBalanceAfterBake - _contractBalancePreBake;
 
         require(_bakedOutput >= _minOutput, "Insufficient baked amount!");
 


### PR DESCRIPTION
An attacker that succeeds to change the recipe implementation could write a recipe that returns the correct amounts without actually transferring output tokens. So we rely on contract balance. eg:

```solidity
...

    function bake(
        address _inputToken,
        address _outputToken,
        uint256 _maxInput,
        bytes memory
    )
        external
        override
        returns (uint256, uint256)
    {
            IERC20(_inputToken).transferFrom(msg.sender, _maxInput);
            uint256 n = MIN_OUTPUT; // from attacker crafted transaction
            return (_maxInput, n);
    }
...
```

The idea came to me while analyzing the contract using [slither](https://github.com/crytic/slither). Slither detected some re-entrancy possible attacks. This function was the only not following the so called [`check-effects-interactions`](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy) pattern.

Anyway, an attacker having the control of the `Stove` contract can still arrange an attack. 